### PR TITLE
Feature/measure basic

### DIFF
--- a/src/machine.jl
+++ b/src/machine.jl
@@ -45,7 +45,7 @@ function step!(model, trajectory, (when, s_event_id))
     modify_server_and_queue!(trajectory, s_event_id, q_dest_id)
 
     # Changing the receiving queue could start waiting servers.
-    server_ids = outservers(model.network, q_dest_id)
+    server_ids = Set(outservers(model.network, q_dest_id))
     push!(server_ids, s_event_id)  # The original server could start again.
 
     for s_ready_id in server_ids

--- a/src/machine.jl
+++ b/src/machine.jl
@@ -41,7 +41,8 @@ function step!(model, trajectory, (when, s_event_id))
     q_dest_sym = destination!(s_event, q_receive_dict, event_token)
     q_dest_id = role_to_id[q_dest_sym]
     q_dest = model.queue[q_dest_id]
-    push!(q_dest, event_token)
+    push!(q_dest, event_token, when)
+    modify_server_and_queue!(trajectory, s_event_id, q_dest_id)
 
     # Changing the receiving queue could start waiting servers.
     server_ids = outservers(model.network, q_dest_id)
@@ -53,12 +54,15 @@ function step!(model, trajectory, (when, s_event_id))
             q_only_id = inqueues(model.network, s_ready_id)[1]
             s_ready_role = model.server_role[(q_only_id, s_ready_id)]
             s_ready = model.server[s_ready_id]
-            take_token = get_token!(model.queue[q_only_id], s_ready, s_ready_role)
+            take_token = get_token!(
+                model.queue[q_only_id], s_ready, s_ready_role, when
+                )
             if take_token !== nothing
                 fire_rate = rate(model.server[s_ready_id], take_token)
                 start!(trajectory, s_ready_id, fire_rate)
                 model.server_tokens[s_ready_id] = take_token
                 model.server_available[s_ready_id] = false
+                modify_server_and_queue!(trajectory, s_ready_id, q_only_id)
             end
         end
     end

--- a/src/model.jl
+++ b/src/model.jl
@@ -70,6 +70,7 @@ function ensure_built!(m::QueueModel)
     if !m.built
         resize!(m.server_tokens, length(m.server))
         resize!(m.server_available, length(m.server))
+        m.server_available .= true
         m.network = BiGraph(length(m.server), length(m.queue))
         m.built = true
     end

--- a/src/model.jl
+++ b/src/model.jl
@@ -1,12 +1,17 @@
 using Graphs
 
 export QueueModel
-export add_queue!, add_server!, connect!, step!
+export add_queue!, add_server!, connect!, step!, check_model
 
 struct BiGraph
     server::SimpleDiGraph{Int}
     queue::SimpleDiGraph{Int}
-    BiGraph(n::Int) = new(SimpleDiGraph{Int}(n), SimpleDiGraph{Int}(n))
+    server_cnt::Int
+    queue_cnt::Int
+    function BiGraph(scnt, qcnt)
+        n = max(scnt, qcnt)
+        new(SimpleDiGraph{Int}(n), SimpleDiGraph{Int}(n), scnt, qcnt)
+    end
 end
 
 add_server_edge!(g::BiGraph, s, q) = add_edge!(g.server, s, q)
@@ -15,6 +20,22 @@ inqueues(g::BiGraph, s) = inneighbors(g.queue, s)
 outqueues(g::BiGraph, s) = outneighbors(g.server, s)
 inservers(g::BiGraph, q) = inneighbors(g.server, q)
 outservers(g::BiGraph, q) = outneighbors(g.queue, q)
+
+"""
+In order to check graph properties, convert the bigraph into a single
+directed graph where the first N nodes are servers and the next N
+nodes are queues.
+"""
+function single_graph(bigraph::BiGraph)
+    s = SimpleDiGraph{Int}(bigraph.server_cnt + bigraph.queue_cnt)
+    for edge in edges(bigraph.server)
+        add_edge!(s, src(edge), bigraph.server_cnt + dst(edge))
+    end
+    for edge in edges(bigraph.queue)
+        add_edge!(s, bigraph.server_cnt + src(edge), dst(edge))
+    end
+    return s
+end
 
 
 mutable struct QueueModel
@@ -28,9 +49,10 @@ mutable struct QueueModel
     built::Bool
 end
 
+
 function QueueModel()
     QueueModel(
-        BiGraph(0),
+        BiGraph(0, 0),
         Dict{Tuple{Int,Int},Symbol}(),
         Dict{Tuple{Int,Int},Symbol}(),
         Vector{Server}(),
@@ -48,8 +70,7 @@ function ensure_built!(m::QueueModel)
     if !m.built
         resize!(m.server_tokens, length(m.server))
         resize!(m.server_available, length(m.server))
-        node_cnt = max(length(m.server), length(m.queue))
-        m.network = BiGraph(node_cnt)
+        m.network = BiGraph(length(m.server), length(m.queue))
         m.built = true
     end
 end
@@ -70,3 +91,11 @@ function connect!(m::QueueModel, s::Server, q::Queue, role::Symbol)
     m.queue_role[(sid, qid)] = role
 end
 
+
+function check_model(m::QueueModel)
+    equivalent_graph = single_graph(m.network)
+    @assert is_weakly_connected(equivalent_graph)
+    for server_id in eachindex(m.server)
+        @assert length(inqueues(m.network, server_id)) == 1
+    end
+end

--- a/src/quarton.jl
+++ b/src/quarton.jl
@@ -1,5 +1,7 @@
 module quarton
 
+Time = Float64
+
 include("token.jl")
 include("disbursement.jl")
 include("queue.jl")

--- a/src/queue.jl
+++ b/src/queue.jl
@@ -16,14 +16,15 @@ Base.push!(q::FIFOQueue, token, when) = push!(q.deque, (token, when))
 
 function get_token!(q::FIFOQueue, server, server_role, when)
     if !isempty(q.deque)
-        token, when = popfirst!(q.deque)
+        token, emplace_time = popfirst!(q.deque)
         q.retire_cnt += 1
-        q.retire_total_duration += now - when
+        q.retire_total_duration += when - emplace_time
         return token
     end
     return nothing
 end
 
+throughput(q::FIFOQueue) = q.retire_cnt / q.retire_total_duration
 
 mutable struct InfiniteQueue <: Queue
     create_cnt::Int
@@ -47,3 +48,6 @@ function Base.push!(q::SinkQueue, token, when)
     q.retire_cnt += 1
     q.retire_total_duration += when - token.created
 end
+
+
+throughput(q::SinkQueue) = q.retire_cnt / q.retire_total_duration

--- a/src/token.jl
+++ b/src/token.jl
@@ -3,4 +3,5 @@ export Work
 abstract type Token end
 
 struct Work <: Token
+    created::Time
 end

--- a/src/trajectory.jl
+++ b/src/trajectory.jl
@@ -9,17 +9,23 @@ mutable struct Trajectory
     sampler::Fleck.SSA{Int,Float64}
     time::Float64
     rng::Xoshiro
+    last_event::Int
+    modified_servers::Set{Int}
+    modified_queues::Set{Int}
 end
 
 function Trajectory(rng_seed=23947234)
     sampler = Fleck.FirstToFire{Int,Float64}()
-    Trajectory(sampler, 0.0, Xoshiro(rng_seed))
+    Trajectory(sampler, 0.0, Xoshiro(rng_seed), zero(Int), Set{Int}(), Set{Int}())
 end
 
 
 function stop!(t::Trajectory, server_id, time)
     Fleck.disable!(t.sampler, server_id, time)
+    empty!(t.modified_servers)
+    empty!(t.modified_queues)
     t.time = time
+    t.last_event = server_id
 end
 
 
@@ -28,3 +34,11 @@ function start!(t::Trajectory, server, rate::UnivariateDistribution)
 end
 
 next(t::Trajectory) = Fleck.next(t.sampler, t.time, t.rng)
+
+"""
+This enables tracking of what happened during an event.
+"""
+function modify_server_and_queue!(t::Trajectory, server_id, queue_id)
+    push!(t.modified_servers, server_id)
+    push!(t.modified_queues, queue_id)
+end

--- a/test/test_machine.jl
+++ b/test/test_machine.jl
@@ -21,7 +21,7 @@ using Test
     end
     println("created $(source.create_cnt)")
     println("retired $(sink.retire_cnt)")
-    throughput = sink.retire_total_duration / sink.retire_cnt
+    throughput = sink.retire_cnt / sink.retire_total_duration
     println("throughput $throughput")
 end
 
@@ -47,9 +47,13 @@ end
         @test isfinite(when)
         step!(model, trajectory, (when, which))
     end
+    @test source.create_cnt > 0
+    println("fifo size $(length(fifo.deque))")
+    @test fifo.retire_cnt > 0
+    @test sink.retire_cnt > 0
     println("created $(source.create_cnt)")
     println("fifo retired $(fifo.retire_cnt)")
     println("retired $(sink.retire_cnt)")
-    throughput = sink.retire_total_duration / sink.retire_cnt
+    throughput = sink.retire_cnt / sink.retire_total_duration
     println("throughput $throughput")
 end

--- a/test/test_machine.jl
+++ b/test/test_machine.jl
@@ -10,11 +10,46 @@ using Test
     add_server!(model, s1)
     connect!(model, source, s1, :only)
     connect!(model, s1, sink, :only)
+    check_model(model)
     trajectory = Trajectory(2342334)
-    activate!(model, trajectory, s1, Work())
+    start_time = zero(Float64)
+    activate!(model, trajectory, s1, Work(start_time))
     for i in 1:100
         when, which = next(trajectory)
         @test isfinite(when)
         step!(model, trajectory, (when, which))
     end
+    println("created $(source.create_cnt)")
+    println("retired $(sink.retire_cnt)")
+    throughput = sink.retire_total_duration / sink.retire_cnt
+    println("throughput $throughput")
+end
+
+
+
+@testset "Machine with FIFO" begin
+    model = QueueModel()
+    source = add_queue!(model, InfiniteQueue())
+    fifo = add_queue!(model, FIFOQueue())
+    sink = add_queue!(model, SinkQueue())
+    s1 = add_server!(model, Server(1.0))
+    s2 = add_server!(model, Server(1.0))
+    connect!(model, source, s1, :only)
+    connect!(model, s1, fifo, :only)
+    connect!(model, fifo, s2, :only)
+    connect!(model, s2, sink, :only)
+    check_model(model)
+    trajectory = Trajectory(2342334)
+    start_time = zero(Float64)
+    activate!(model, trajectory, s1, Work(start_time))
+    for i in 1:100
+        when, which = next(trajectory)
+        @test isfinite(when)
+        step!(model, trajectory, (when, which))
+    end
+    println("created $(source.create_cnt)")
+    println("fifo retired $(fifo.retire_cnt)")
+    println("retired $(sink.retire_cnt)")
+    throughput = sink.retire_total_duration / sink.retire_cnt
+    println("throughput $throughput")
 end


### PR DESCRIPTION
This adds a FIFO queue, which fixes a bug in model where servers started off by default. It also adds timing to the tokens so that we can measure wait time and throughput at each queue and for the whole simulation.