### PR TITLE
Feature/queue distribution

### DIFF
--- a/src/disbursement.jl
+++ b/src/disbursement.jl
@@ -23,3 +23,12 @@ function destination!(r::RoundRobin, queue_dict, token)
     r.next = mod1(r.next + 1, length(queue_dict))
     return r.role[n]
 end
+
+
+
+function update_downstream!(r::RoundRobin, downstream, when, rng)
+    q_dest = queues(downstream)
+    push!(downstream, q_dest[r.next], when)
+    r.next = mod1(r.next + 1, length(q_dest))
+    return q_dest[r.next]
+end

--- a/src/disbursement.jl
+++ b/src/disbursement.jl
@@ -15,17 +15,6 @@ mutable struct RoundRobin <: Disbursement
 end
 
 
-function destination!(r::RoundRobin, queue_dict, token)
-    if length(r.role) < length(queue_dict)
-        r.role = collect(keys(queue_dict))
-    end
-    n = r.next
-    r.next = mod1(r.next + 1, length(queue_dict))
-    return r.role[n]
-end
-
-
-
 function update_downstream!(r::RoundRobin, downstream, when, rng)
     q_dest = queues(downstream)
     push!(downstream, q_dest[r.next], when)

--- a/src/downstream.jl
+++ b/src/downstream.jl
@@ -1,0 +1,51 @@
+
+# Both queues and servers need to be able to express logic about
+# where tokens go next. I call it disbursement. In order to do that,
+# they need to see their local environment. If we implemented the model
+# with an object-oriented method, that might mean just giving them access
+# to the list of downstream objects. Here, that state is held elsewhere
+# more efficiently. So this file creates flyweights to give each server
+# and queue access to make the choices it needs to make.
+
+struct QueueDownstream
+    model::QueueModel
+    trajectory::Trajectory
+    q_id::Int
+end
+
+
+function available_servers(d::QueueDownstream)
+    return [
+        d.model.server[idx] for idx in outservers(d.model.network, d.q_id)
+        if d.model.server_available[idx]
+    ]
+end
+
+
+function Base.push!(d::QueueDownstream, server, token)
+    fire_rate = rate(server, token)
+    s_id = id(server)
+    start!(d.trajectory, s_id, fire_rate)
+    d.model.server_tokens[s_id] = token
+    d.model.server_available[s_id] = false
+    modify_server_and_queue!(d.trajectory, s_id, d.q_id)
+end
+
+
+struct ServerDownstream
+    model::QueueModel
+    trajectory::Trajectory
+    s_id::Int
+end
+
+
+function queues(d::ServerDownstream)
+    [d.model.queue[idx] for idx in outqueues(d.model.network, d.s_id)]
+end
+
+
+# There is no token argument because it's always the one token.
+function Base.push!(d::ServerDownstream, queue, when)
+    push!(queue, d.model.server_tokens[d.s_id], when)
+    modify_server_and_queue!(d.trajectory, d.s_id, id(queue))
+end

--- a/src/machine.jl
+++ b/src/machine.jl
@@ -27,28 +27,14 @@ function step!(model, trajectory, (when, s_event_id))
     modify!(s_event, event_token)
     model.server_available[s_event_id] = true
 
-    # That event_token will go to one of the queues waiting for it.
-    q_receive_ids = outqueues(model.network, s_event_id)
-    # All this setup making temporary dictionaries is meant to allow users'
-    # code to focus on outgoing queues and their roles.
-    q_receive_dict = Dict{Symbol,Queue}()
-    role_to_id = Dict{Symbol,Int}()
-    for q_id in q_receive_ids
-        role = model.queue_role[(s_event_id, q_id)]
-        q_receive_dict[role] = model.queue[q_id]
-        role_to_id[role] = q_id
-    end
-    q_dest_sym = destination!(s_event, q_receive_dict, event_token)
-    q_dest_id = role_to_id[q_dest_sym]
-    q_dest = model.queue[q_dest_id]
-    push!(q_dest, event_token, when)
-    modify_server_and_queue!(trajectory, s_event_id, q_dest_id)
+    s_downstream = ServerDownstream(model, trajectory, s_event_id)
+    q_dest = update_downstream!(s_event, s_downstream, when, trajectory.rng)
 
     # We care about two queues, the one that feeds the server that fired
     # and the one that just received a token. No others. Each of those
     # two gets to decide which available server can get a token.
     queue_ids = Set(inqueues(model.network, s_event_id))
-    push!(queue_ids, q_dest_id)
+    push!(queue_ids, id(q_dest))
     for q_update_id in queue_ids
         downstream = QueueDownstream(model, trajectory, q_update_id)
         update_downstream!(

--- a/src/machine.jl
+++ b/src/machine.jl
@@ -49,32 +49,10 @@ function step!(model, trajectory, (when, s_event_id))
     # two gets to decide which available server can get a token.
     queue_ids = Set(inqueues(model.network, s_event_id))
     push!(queue_ids, q_dest_id)
-    
-
-    # Changing the receiving queue could start waiting servers.
-    server_ids = Set(outservers(model.network, q_dest_id))
-    push!(server_ids, s_event_id)  # The original server could start again.
-
-    # Which of the ready servers get which tokens?
-    # That logic sits in the queues that distribute tokens to servers.
-    # If more than one server is available at the same time, the server
-    # decides.
-    for s_ready_id in server_ids
-        if model.server_available[s_ready_id]
-            # There is exactly one input queue for each server.
-            q_only_id = inqueues(model.network, s_ready_id)[1]
-            s_ready_role = model.server_role[(q_only_id, s_ready_id)]
-            s_ready = model.server[s_ready_id]
-            take_token = get_token!(
-                model.queue[q_only_id], s_ready, s_ready_role, when
-                )
-            if take_token !== nothing
-                fire_rate = rate(model.server[s_ready_id], take_token)
-                start!(trajectory, s_ready_id, fire_rate)
-                model.server_tokens[s_ready_id] = take_token
-                model.server_available[s_ready_id] = false
-                modify_server_and_queue!(trajectory, s_ready_id, q_only_id)
-            end
-        end
+    for q_update_id in queue_ids
+        downstream = QueueDownstream(model, trajectory, q_update_id)
+        update_downstream!(
+            model.queue[q_update_id], downstream, when, trajectory.rng
+            )
     end
 end

--- a/src/model.jl
+++ b/src/model.jl
@@ -63,8 +63,17 @@ function QueueModel()
         )
 end
 
-add_server!(m::QueueModel, server) = (push!(m.server, server); server)
-add_queue!(m::QueueModel, queue) = (push!(m.queue, queue); queue)
+function add_server!(m::QueueModel, server)
+    push!(m.server, server)
+    id!(server, length(m.server))
+    return server
+end
+
+function add_queue!(m::QueueModel, queue)
+    push!(m.queue, queue)
+    id!(queue, length(m.queue))
+    queue
+end
 
 function ensure_built!(m::QueueModel)
     if !m.built

--- a/src/quarton.jl
+++ b/src/quarton.jl
@@ -8,6 +8,7 @@ include("queue.jl")
 include("server.jl")
 include("model.jl")
 include("trajectory.jl")
+include("downstream.jl")
 include("machine.jl")
 
 end # module quarton

--- a/src/queue.jl
+++ b/src/queue.jl
@@ -1,7 +1,7 @@
 
 using DataStructures
 
-export Queue, InfiniteQueue, FIFOQueue, SinkQueue
+export Queue, InfiniteSourceQueue, FIFOQueue, SinkQueue
 
 abstract type Queue end
 
@@ -36,13 +36,13 @@ end
 
 throughput(q::FIFOQueue) = q.retire_cnt / q.retire_total_duration
 
-mutable struct InfiniteQueue <: Queue
+mutable struct InfiniteSourceQueue <: Queue
     create_cnt::Int
     id::Int
-    InfiniteQueue() = new(zero(Int), zero(Int))
+    InfiniteSourceQueue() = new(zero(Int), zero(Int))
 end
 
-function update_downstream!(q::InfiniteQueue, downstream, when, rng)
+function update_downstream!(q::InfiniteSourceQueue, downstream, when, rng)
     for s in available_servers(downstream)
         q.create_cnt += 1
         push!(downstream, s, Work(when))
@@ -61,7 +61,7 @@ end
 
 function Base.push!(q::SinkQueue, token, when)
     q.retire_cnt += 1
-    q.retire_total_duration += when - token.created
+    q.retire_total_duration += when - created(token)
 end
 
 

--- a/src/queue.jl
+++ b/src/queue.jl
@@ -5,11 +5,16 @@ export Queue, InfiniteQueue, FIFOQueue, SinkQueue
 
 abstract type Queue end
 
+id!(q::Queue, id::Int) = (q.id = id; q)
+id(q::Queue) = q.id
+
+
 mutable struct FIFOQueue <: Queue
     deque::Deque{Tuple{Token,Time}}
     retire_cnt::Int
     retire_total_duration::Time
-    FIFOQueue() = new(Deque{Tuple{Token,Time}}(), zero(Int), zero(Time))
+    id::Int
+    FIFOQueue() = new(Deque{Tuple{Token,Time}}(), zero(Int), zero(Time), zero(Int))
 end
 
 Base.push!(q::FIFOQueue, token, when) = push!(q.deque, (token, when))
@@ -28,7 +33,8 @@ throughput(q::FIFOQueue) = q.retire_cnt / q.retire_total_duration
 
 mutable struct InfiniteQueue <: Queue
     create_cnt::Int
-    InfiniteQueue() = new(zero(Int))
+    id::Int
+    InfiniteQueue() = new(zero(Int), zero(Int))
 end
 
 function get_token!(q::InfiniteQueue, server, server_role, when)
@@ -40,7 +46,8 @@ end
 mutable struct SinkQueue <: Queue
     retire_cnt::Int
     retire_total_duration::Time
-    SinkQueue() = new(zero(Int), zero(Time))
+    id::Int
+    SinkQueue() = new(zero(Int), zero(Time), zero(Int))
 end
 
 

--- a/src/queue.jl
+++ b/src/queue.jl
@@ -34,16 +34,6 @@ function update_downstream!(q::FIFOQueue, downstream, when, rng)
 end
 
 
-function get_token!(q::FIFOQueue, server, server_role, when)
-    if !isempty(q.deque)
-        token, emplace_time = popfirst!(q.deque)
-        q.retire_cnt += 1
-        q.retire_total_duration += when - emplace_time
-        return token
-    end
-    return nothing
-end
-
 throughput(q::FIFOQueue) = q.retire_cnt / q.retire_total_duration
 
 mutable struct InfiniteQueue <: Queue
@@ -58,11 +48,6 @@ function update_downstream!(q::InfiniteQueue, downstream, when, rng)
         push!(downstream, s, Work(when))
     end
     nothing
-end
-
-function get_token!(q::InfiniteQueue, server, server_role, when)
-    q.create_cnt += 1
-    Work(when)
 end
 
 

--- a/src/queue.jl
+++ b/src/queue.jl
@@ -19,6 +19,21 @@ end
 
 Base.push!(q::FIFOQueue, token, when) = push!(q.deque, (token, when))
 
+function update_downstream!(q::FIFOQueue, downstream, when, rng)
+    s_available = available_servers(downstream)
+    shuffle!(rng, s_available)
+    for s in s_available
+        if !isempty(q.deque)
+            token, emplace_time = popfirst!(q.deque)
+            q.retire_cnt += 1
+            q.retire_total_duration += when - emplace_time
+            push!(downstream, s, token)
+        end
+    end
+    nothing
+end
+
+
 function get_token!(q::FIFOQueue, server, server_role, when)
     if !isempty(q.deque)
         token, emplace_time = popfirst!(q.deque)
@@ -35,6 +50,14 @@ mutable struct InfiniteQueue <: Queue
     create_cnt::Int
     id::Int
     InfiniteQueue() = new(zero(Int), zero(Int))
+end
+
+function update_downstream!(q::InfiniteQueue, downstream, when, rng)
+    for s in available_servers(downstream)
+        q.create_cnt += 1
+        push!(downstream, s, Work(when))
+    end
+    nothing
 end
 
 function get_token!(q::InfiniteQueue, server, server_role, when)
@@ -58,3 +81,5 @@ end
 
 
 throughput(q::SinkQueue) = q.retire_cnt / q.retire_total_duration
+
+update_downstream!(q::SinkQueue, downstream, when, rng) = nothing

--- a/src/server.jl
+++ b/src/server.jl
@@ -13,15 +13,19 @@ using Random
 export Server
 
 
-struct Server
+mutable struct Server
     rate::UnivariateDistribution
     modify_token::Function
     disbursement::Disbursement
+    id::Int
 end
 
 function Server(rate::Float64)
-    Server(Exponential(rate), identity, RoundRobin())
+    Server(Exponential(rate), identity, RoundRobin(), zero(Int))
 end
+
+id!(s::Server, id::Int) = (s.id = id; s)
+id(s::Server) = s.id
 
 set_rate!(s::Server, rate::Float64) = (s.rate = Exponential(rate); nothing)
 set_rate!(s::Server, rate::UnivariateDistribution) = (s.rate = rate; nothing)

--- a/src/server.jl
+++ b/src/server.jl
@@ -35,3 +35,8 @@ modify!(s::Server, token) = (s.modify_token(token); nothing)
 function destination!(s::Server, queue_dict, token)
     return destination!(s.disbursement, queue_dict, token)
 end
+
+
+function update_downstream!(s::Server, downstream, when, rng)
+    update_downstream!(s.disbursement, downstream, when, rng)
+end

--- a/src/server.jl
+++ b/src/server.jl
@@ -27,14 +27,8 @@ end
 id!(s::Server, id::Int) = (s.id = id; s)
 id(s::Server) = s.id
 
-set_rate!(s::Server, rate::Float64) = (s.rate = Exponential(rate); nothing)
-set_rate!(s::Server, rate::UnivariateDistribution) = (s.rate = rate; nothing)
 rate(s::Server, token) = s.rate
 modify!(s::Server, token) = (s.modify_token(token); nothing)
-
-function destination!(s::Server, queue_dict, token)
-    return destination!(s.disbursement, queue_dict, token)
-end
 
 
 function update_downstream!(s::Server, downstream, when, rng)

--- a/src/token.jl
+++ b/src/token.jl
@@ -5,3 +5,6 @@ abstract type Token end
 struct Work <: Token
     created::Time
 end
+
+created(t::Token) = 0.0
+created(t::Work) = t.created

--- a/test/test_machine.jl
+++ b/test/test_machine.jl
@@ -2,7 +2,7 @@ using Test
 
 @testset "Run simple machine" begin
     model = QueueModel()
-    source = InfiniteQueue()
+    source = InfiniteSourceQueue()
     sink = SinkQueue()
     s1 = Server(1.0)
     add_queue!(model, source)
@@ -29,7 +29,7 @@ end
 
 @testset "Machine with FIFO" begin
     model = QueueModel()
-    source = add_queue!(model, InfiniteQueue())
+    source = add_queue!(model, InfiniteSourceQueue())
     fifo = add_queue!(model, FIFOQueue())
     sink = add_queue!(model, SinkQueue())
     s1 = add_server!(model, Server(1.0))


### PR DESCRIPTION
This changes how both servers and queues distribute tokens to queues and servers that follow in the network. It constructs a flyweight representation of the downstream nodes so that the functions that do the deciding are easier to write.